### PR TITLE
Use virtualenv for installing Renku

### DIFF
--- a/aiida/Dockerfile
+++ b/aiida/Dockerfile
@@ -39,8 +39,8 @@ ARG RENKU_VERSION=0.14.2
 # Do not edit this section and do not add anything below
 
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    pipx uninstall renku && \
-    pipx install --force renku==${RENKU_VERSION} \
+    pip uninstall renku && \
+    pip install --force renku==${RENKU_VERSION} \
     ; fi
 
 ########################################################

--- a/aiida/Dockerfile
+++ b/aiida/Dockerfile
@@ -33,7 +33,7 @@ RUN /opt/conda/bin/pip install -r /tmp/requirements.txt && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.14.2
+ARG RENKU_VERSION=0.16.0
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/aiida/Dockerfile
+++ b/aiida/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.8-20f653d
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.10.1
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/aiida/Dockerfile
+++ b/aiida/Dockerfile
@@ -39,8 +39,12 @@ ARG RENKU_VERSION=0.16.0
 # Do not edit this section and do not add anything below
 
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    pip uninstall renku && \
-    pip install --force renku==${RENKU_VERSION} \
-    ; fi
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku ; \
+            pip install --force renku==${RENKU_VERSION} ;\
+        fi \
+    fi
 
 ########################################################

--- a/python-minimal-streamlit/Dockerfile
+++ b/python-minimal-streamlit/Dockerfile
@@ -27,7 +27,7 @@ RUN conda env update -q -f /tmp/environment.yml && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.13.0
+ARG RENKU_VERSION=0.16.0
 
 # to run streamlit
 COPY jupyter_notebook_config.py ~/.jupyter/

--- a/python-minimal-streamlit/Dockerfile
+++ b/python-minimal-streamlit/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.7-0.7.3
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.10.1
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/python-minimal-streamlit/Dockerfile
+++ b/python-minimal-streamlit/Dockerfile
@@ -36,8 +36,12 @@ COPY jupyter_notebook_config.py ~/.jupyter/
 # Do not edit this section and do not add anything below
 
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    pip uninstall renku && \
-    pip install --force renku==${RENKU_VERSION} \
-    ; fi
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku ; \
+            pip install --force renku==${RENKU_VERSION} ;\
+        fi \
+    fi
 
 ########################################################

--- a/python-minimal-streamlit/Dockerfile
+++ b/python-minimal-streamlit/Dockerfile
@@ -36,8 +36,8 @@ COPY jupyter_notebook_config.py ~/.jupyter/
 # Do not edit this section and do not add anything below
 
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    pipx uninstall renku && \
-    pipx install --force renku==${RENKU_VERSION} \
+    pip uninstall renku && \
+    pip install --force renku==${RENKU_VERSION} \
     ; fi
 
 ########################################################

--- a/python-minimal-streamlit/README.md
+++ b/python-minimal-streamlit/README.md
@@ -1,6 +1,6 @@
 # python-minimal-streamlit
 
-This is a streamlit template based on the basic Python (3.7) template.
+This is a streamlit template based on the basic Python (3.9) template.
 
 ## Introduction
 


### PR DESCRIPTION
- use virtualenv instead of pipx for installing Renku (see issue with setuptools https://renku.discourse.group/t/error-during-environment-creation/407/6) 
- update renku version

- test projects created in https://renkulab.io/projects/pamela.delgado/test-streamlit-template-fixed and 
https://renkulab.io/projects/pamela.delgado/test-aiida-template-fixed, images build properly and the newer version of renku is installed

