### PR TITLE
chore: fix failing streamlit build 

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@
     archive_url: (optional) URL to AiiDA archive to be imported upon starting an environment
 - folder: python-minimal-streamlit
   name: Streamlit
-  description: Streamlit template based on a basic Python (3.7) project.
+  description: Streamlit template based on a basic Python (3.9) project.
   variables: {}
 - folder: desktop
   name: Renku Desktop

--- a/python-minimal-streamlit/Dockerfile
+++ b/python-minimal-streamlit/Dockerfile
@@ -30,7 +30,7 @@ RUN conda env update -q -f /tmp/environment.yml && \
 ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
 
 # to run streamlit
-COPY jupyter_notebook_config.py ~/.jupyter/
+COPY jupyter_notebook_config.py ${HOME}/.jupyter/
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/python-minimal-streamlit/Dockerfile
+++ b/python-minimal-streamlit/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.13.1
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.14.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/python-minimal-streamlit/environment.yml
+++ b/python-minimal-streamlit/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - pip>=22.1.2:
+  - pip:
     - streamlit>=1.10.0
     - jupyter-server-proxy>=3.2.1
 prefix: "/opt/conda"

--- a/python-minimal-streamlit/environment.yml
+++ b/python-minimal-streamlit/environment.yml
@@ -7,4 +7,5 @@ dependencies:
   - pip:
     - streamlit>=1.10.0
     - jupyter-server-proxy>=3.2.1
+    - traitlets<5.9.0
 prefix: "/opt/conda"

--- a/python-minimal-streamlit/environment.yml
+++ b/python-minimal-streamlit/environment.yml
@@ -7,5 +7,4 @@ dependencies:
   - pip:
     - streamlit>=1.10.0
     - jupyter-server-proxy>=3.2.1
-    - traitlets<5.9.0
 prefix: "/opt/conda"


### PR DESCRIPTION
This fixes the error in the conda environment file as well as a path error in the Dockerfile. ~~It also pins `traitlets<5.9.0` which has been found to cause problems for the jupyter-server-proxy~~ Pinning of `traitlets` is, in fact, not needed. 