### PR TITLE
persist RStudio config to the project by default

### DIFF
--- a/Renv/Dockerfile
+++ b/Renv/Dockerfile
@@ -41,8 +41,8 @@ COPY renv.lock /home/rstudio/renv.lock
 COPY install.R /tmp/
 RUN R -f /tmp/install.R
 
-# To apply a custom RStudio config uncomment the line below
-# ENV RSTUDIO_CONFIG_HOME=/home/rstudio/work/{{ __sanitized_project_name__ }}/.rstudio_config_dir
+# make RStudio config persistent
+ENV RSTUDIO_CONFIG_HOME=/home/rstudio/work/{{ __sanitized_project_name__ }}/.rstudio_config_dir
 
 ## Clean up the /home/rstudio directory to avoid confusion in nested R projects
 RUN rm /home/rstudio/.Rprofile; rm /home/rstudio/renv.lock


### PR DESCRIPTION
Changes the default behaviour wherein any changes made to the RStudio global config do not persist between sessions by setting an environment variable to point to a file in the project directory.