### PR TITLE
additional common system dependency of R plotting libraries

### DIFF
--- a/Renv/Dockerfile
+++ b/Renv/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -y update && \
     jq \
     curl \
     librsvg2-2 \
+    librsvg2-bin \
     librsvg2-dev \
     librsvg2-common
 


### PR DESCRIPTION
lack of librsvg2-bin has caused installation issues for me with some R packages using rsvg