### PR TITLE
🐛 Fix git-based user/email info for aiida profile

### DIFF
--- a/aiida/post-init.sh
+++ b/aiida/post-init.sh
@@ -5,11 +5,12 @@
 # Parse first/last name from GIT_AUTHOR_NAME
 # See https://stackoverflow.com/a/17841619/1069467
 function join_by { local d=$1; shift; local f=$1; shift; printf %s "$f" "${@/#/$d}"; }
-user=($GIT_AUTHOR_NAME)
+user="$(git config user.name)"
 first_name=${user[0]}
-last_name=`join_by ' ' "${user[@]:1}"`
+last_name=$(join_by ' ' "${user[@]:1}")
+email="$(git config user.email)"
 
-project_dir=`pwd`
+project_dir=$(pwd)
 
 cat > aiida_config.yaml <<EOF
 store_path: "${project_dir}/repo"
@@ -27,7 +28,7 @@ db_username: aiidauser
 db_password: verdi
 
 profile: "default"
-email: "$EMAIL"
+email: "$email"
 first_name: "$first_name"
 last_name: "$last_name"
 institution: Renkulab
@@ -35,7 +36,7 @@ institution: Renkulab
 non_interactive: true
 EOF
 
-# Add AIIDA_PATH environment variable 
+# Add AIIDA_PATH environment variable
 export AIIDA_PATH="${project_dir}/repo"
 
 # todo: Enable AiiDA line magic


### PR DESCRIPTION
This PR provides a first fix for the broken AiiDA template for RenkuLab.

Recently, trying to explore an AiiDA archive from Materials Cloud via RenkuLab created a Jupyter Notebook in which the provided code wasn't working due to a missing AiiDA profile. Manual profile creation via the shell would alleviate the issue, so the Docker image and AiiDA setup itself seem to be (in principle) still fine. As it turns out, though, the `$GIT_AUTHOR_NAME` and `$EMAIL` environment variables are unset, which is why the creation of the AiiDA profile on startup via the `post-init.sh` script fails. Now, the relevant information is obtained via `git config`, fixing the current problem.

However, the overall template is a bit outdated, using AiiDA v.1.6, and the `aiida-activate` tool, which has not been
changed in the last 4 years. I have another PR in the pipeline that updates the template, i.e. using AiiDA v2.5,
removing the `aiida-activate` dependency, and providing a new Docker image, but we're still testing some things. It'll
come soon, though :)