### PR TITLE
fix: update AiiDA version, docker, and post-init.sh

### DIFF
--- a/aiida/.gitignore
+++ b/aiida/.gitignore
@@ -337,4 +337,5 @@ tags
 .renku/tmp
 .renku/cache
 
-aiida_config.yaml
+# AiiDA
+aiida_data

--- a/aiida/.renku/renku.ini
+++ b/aiida/.renku/renku.ini
@@ -1,5 +1,5 @@
 [renku "interactive"]
-{% if archive_url %}
 default_url = /lab/tree/notebooks/explore.ipynb
-{% endif %}
-image = registry.renkulab.io/leopold.talirz1/build-new-docker-image:41b84af
+image = registry.renkulab.io/julian.geiger/aiida-renku-dev:latest
+cpu_request = 1.0
+mem_request = 2G

--- a/aiida/Dockerfile
+++ b/aiida/Dockerfile
@@ -2,37 +2,41 @@
 # https://github.com/SwissDataScienceCenter/renkulab-docker
 FROM renku/renkulab-py:3.10-0.22.0
 
+# Effectively disable RabbitMQ `consumer_timeout`
+ENV RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-rabbit consumer_timeout undefined"
+
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
 # Uncomment and adapt if your R or python packages require extra linux (ubuntu) software
 # e.g. the following installs apt-utils and vim; each pkg on its own line, all lines
 # except for the last end with backslash '\' to continue the RUN line
-#
 USER root
 RUN apt-get update && \
-   apt-get install -y --no-install-recommends \
-   tzdata
+    apt-get install -y --no-install-recommends \
+    tzdata
+
 USER ${NB_USER}
 
-
 # install the python dependencies
-COPY requirements.txt environment.yml /tmp/
+COPY environment.yml /tmp/
 RUN mamba env update -q -f /tmp/environment.yml
 
-# get around pyyaml upgrade error ("Cannot uninstall 'PyYAML'. It is a distutils installed project...")
-RUN /opt/conda/bin/pip install --upgrade --force-reinstall pip==9.0.3 && \
-    /opt/conda/bin/pip install pyyaml==5.1.2 --disable-pip-version-check && \
-    /opt/conda/bin/pip install --upgrade pip
-
-RUN /opt/conda/bin/pip install -r /tmp/requirements.txt && \
+RUN /opt/conda/bin/pip install --upgrade pip && \
     conda clean -y --all && \
     conda env export -n "root"
+
+RUN pip install --upgrade pip
+
+RUN pip install aiida-core~=2.5
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("2.9.1") }}
+
+# For local build
+# ARG RENKU_VERSION="2.9.1"
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/aiida/README.md
+++ b/aiida/README.md
@@ -1,4 +1,5 @@
 # {{ name }}
+
 {% if __project_description__ %}
 {{ __project_description__ }}
 {% endif %}
@@ -7,25 +8,29 @@
 This project comes with a Jupyter notebook for importing and exploring an [AiiDA archive]({{ archive_url }}).
 {% endif %}
 
-### Introduction
+## Introduction
 
 This project comes with a pre-configured AiiDA environment:
 
- 1. Start a new environment (e.g. 1 CPU, 2GB memory) from the `Sessions` tab of your Renku project
- 2. Open the terminal and type
- ```
-    $ verdi status
-     ✔ config dir:  /work/{{ __sanitized_project_name__ }}/repo/.aiida
-     ✔ profile:     On profile default
-     ✔ repository:  /work/{{ __sanitized_project_name__ }}/repo/.aiida/repository/default
-     ✔ postgres:    Connected as aiidauser@localhost:5432
-     ✔ rabbitmq:    Connected as amqp://guest:guest@127.0.0.1:5672?heartbeat=600
-     ⏺ daemon:      The daemon is not running
- ```
- 3. Open the Jupyter notebook in the `notebooks/` folder or see below for how to get started with AiiDA.
+1.  `⏵Start` a new session (e.g. `small`, the default) from the `Sessions` tab located in the top right of your Renku project
+2.  If the project was created from a [Materials Cloud Archive](https://archive.materialscloud.org) or an `archive_url`
+    was provided, it will be already imported in the `aiida_renku` default profile, and you can immediately start
+    exploring it via the Jupyter Notebook that opens up (the raw file is located in the "repo" directory)
+3.  To see the overall status of the `AiiDA` setup you can open a terminal via the `Launcher` and type `verdi status`. It should look something like this:
 
-### Learning about AiiDA
+    ```shell
+    ✔ version:     AiiDA v2.5.1
+    ✔ config:      /home/jovyan/work/aiida-final-archive/repo/.aiida
+    ✔ profile:     aiida_renku
+    ✔ storage:     SqliteZip storage (read-only) [open] @ /home/jovyan/work/{{ name }}/repo/<archive_name>.aiida
+    ✔ rabbitmq:    Connected to RabbitMQ v3.12.12 as amqp://guest:guest@127.0.0.1:5672?heartbeat=600
+    ⏺ daemon:      The daemon is not running.
+    ```
 
- * [Introductory AiiDA tutorial](https://aiida.readthedocs.io/projects/aiida-core/en/latest/intro/tutorial.html), part of the [AiiDA documentation](https://aiida.readthedocs.io).
- * A [collection of historic AiiDA tutorials](https://aiida-tutorials.readthedocs.io/en/latest/).
- * The [AiiDA web site](http://www.aiida.net)
+## Learning about AiiDA
+
+Further resources about AiiDA can be found here
+
+- [Introductory AiiDA tutorial](https://aiida.readthedocs.io/projects/aiida-core/en/latest/intro/tutorial.html), part of the [AiiDA documentation](https://aiida.readthedocs.io)
+- A [collection of historic AiiDA tutorials](https://aiida-tutorials.readthedocs.io/en/latest/)
+- The [AiiDA web site](http://www.aiida.net)

--- a/aiida/environment.yml
+++ b/aiida/environment.yml
@@ -1,11 +1,6 @@
 name: "base"
 channels:
   - conda-forge
-  - cjs14
 dependencies:
-# - aiida-core
-- aiida-core.services
-- activate-aiida
-# while aiida-core.services requires rabbitmq-server>=3.7, for some reason version 3.6.15 is installed without the line below
-- rabbitmq-server>=3.8
+- aiida-core.services=2.2.2
 prefix: "/opt/conda"

--- a/aiida/notebooks/explore.ipynb
+++ b/aiida/notebooks/explore.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Import AiiDA archive file \n"
+    "# Import AiiDA archive file\n"
    ]
   },
   {
@@ -13,8 +13,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# iPython magic\n",
+    "%load_ext aiida\n",
+    "%aiida\n",
     "{% if archive_url %}\n",
-    "!verdi archive import \"{{ archive_url }}\"\n",
+    "# !verdi archive import \"{{ archive_url }}\"\n",
     "{% else %}\n",
     "# Optional\n",
     "!verdi archive import \"https://path/to/archive.aiida\"\n",
@@ -26,7 +29,8 @@
    "metadata": {},
    "source": [
     "# Query AiiDA provenance graph\n",
-    "For more information see [the AiiDA documentation](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html)"
+    "\n",
+    "For more information see [the AiiDA documentation](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html)\n"
    ]
   },
   {
@@ -36,6 +40,7 @@
    "outputs": [],
    "source": [
     "from aiida import orm, load_profile\n",
+    "\n",
     "load_profile()  # load default AiiDA profile"
    ]
   },

--- a/aiida/requirements.txt
+++ b/aiida/requirements.txt
@@ -1,1 +1,1 @@
-aiida-core~=1.6.1,!=1.6.2
+aiida-core~=2.5


### PR DESCRIPTION
# Fix and update the RenkuLab AiiDA template

This PR updates the AiiDA template for RenkuLab.

Regarding the broken profile creation on start-up, see PR #78.

## Main changes

- The `Dockerfile` is updated, and a new image pinned in `renku.ini` (using the latest `renku` 0.22 Python 3.10 base
  image and an AiiDA v2.5.1 installation)
- `aiida-activate` was removed as the [repo](https://github.com/chrisjsewell/activate_aiida) is outdated
- Instead, the AiiDA profile is set up via `verdi profile setup` in the `post-init.sh` script, where depending on the presence (absence) of the `archive_url` the `sqlite_zip` (`sqlite_dos`) backends are used
- Currently, the AiiDA Postgres backend (`psql_dos`) cannot be used due to missing `sudo` access &rarr; For inspection `sqlite_zip` and `sqlite_dos` should be sufficient (frankly, I tried resolving that using the `aiida-core` Docker images/Dockerfiles for some time, but didn't manage to make it work, and the effort might not be worth it if we stick to the other backends)
- RabbitMQ is working as expected as it is installed via the `aiida-core.services` `conda` package, the `consumer_timeout` variable is set, and the version warning disabled
- Minor changes to the `explore` notebook and the README

## Some further notes

Currently, the directory where the archive is downloaded is "repo", but one could also use the existing "data" directory instead? I think this ties in with our discussion about `verdi init`, @sphuber and @giovannipizzi. If we manage to merge these changes soon, we could update the setup here - for now it works in the classical way. Pinging @ltalirz and @khsrali here for info as well.

If somebody wants to take it for a spin before the merge, you can provide my [repository URL](https://github.com/GeigerJ2/contributed-project-templates) and the [latest commit SHA of this PR](https://github.com/SwissDataScienceCenter/contributed-project-templates/commit/c6ae7e013d5360d51fd0c4450d3bb695a34c1ec7) when [creating a new RenkuLab project](https://renkulab.io/projects/new), and fetch the updated template (see screenshot below).

Would be happy about feedback or suggestions for improvement. We also had the idea of providing some additional custom code, which already gives some interesting information about the archive (e.g. as a `pandas` dataframe), though, I think this should be as agnostic of the structure of the data as possible and would warrant a separate PR either way.

Lastly, when trying to import [this archive](https://archive.materialscloud.org/record/file?record_id=2100&file_id=18486bd2-4eaa-49aa-bd8d-eb88e02f394a&filename=eclab.aiida) **after** the notebook is created (that is, not providing an `archive_url` initially), I'm getting a `NotImplementedError` (see screenshot below), while pure inspection via `sqlite_zip` without importing works. I haven't investigated it further so far, but could this be possibly a case in which an automatic migration is required, @superstar54?

## Creating a project from the template

![image](https://github.com/SwissDataScienceCenter/contributed-project-templates/assets/41700727/3ee4b21e-4676-4d93-a9a9-1294e3fb7017)

## `NotImplementedError` on `archive import`

![image](https://github.com/SwissDataScienceCenter/contributed-project-templates/assets/41700727/ac04b9bb-dc12-47e0-a664-06e84a9ffc53)